### PR TITLE
Upgrade to ldclient-js 1.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-babel": "^7.7.3",
     "ember-test-waiters": "^1.1.1",
     "event-source-polyfill": "^0.0.9",
-    "ldclient-js": "1.1.12"
+    "ldclient-js": "1.7.4"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -830,10 +830,10 @@
   resolved "https://registry.yarnpkg.com/@types/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz#4151a81b4052c80bc2becbae09f3a9ec010a9c7a"
   integrity sha512-Lja2xYuuf2B3knEsga8ShbOdsfNOtzT73GyJmZyY7eGl2+ajOqrs8yM5ze0fsSoYwvA6bw7/Qr7OZ7PEEmYwWg==
 
-Base64@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/Base64/-/Base64-1.0.0.tgz#b6b73ee342ce64bf66d6003a4536683bf8a349b5"
-  integrity sha1-trc+40LOZL9m1gA6RTZoO/ijSbU=
+Base64@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/Base64/-/Base64-1.0.1.tgz#def45cc50c961bcc9bf2321d0f52bcbfec1f1bb1"
+  integrity sha1-3vRcxQyWG8yb8jIdD1K8v+wfG7E=
 
 abbrev@1:
   version "1.1.0"
@@ -6617,12 +6617,12 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-ldclient-js@1.1.12:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/ldclient-js/-/ldclient-js-1.1.12.tgz#06ea0dc2326bd84116f0c6674ccd8ff7a83e7d8d"
-  integrity sha512-QIOyVxQCV8Ao+Epk2sVDZzDWxwvRoaV1aCIxPEArGF5i3Fkbcjk14V6BJ2wLAJCl9xQUy0VqDWbS5qxY06iWIA==
+ldclient-js@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/ldclient-js/-/ldclient-js-1.7.4.tgz#5e6def39ea1133e8a3dd8f93dab442a2db9f103f"
+  integrity sha512-qfhxp2cnO8X8pXfspm7KYztPutBbIe9V+byjL4jnPqhiRj7+49Ejbjcy6fF2OsglHbZXi28TO7laBKiCE/0ZuQ==
   dependencies:
-    Base64 "1.0.0"
+    Base64 "1.0.1"
     escape-string-regexp "1.0.5"
 
 leek@0.0.24:


### PR DESCRIPTION
Hey @achambers, as a first step I upgraded the `ldclient-js` library to version 1.7.4, which is the one right before 2.0.0. I did this to bisect the rather large jump in version numbers, so that when the upgrade to 2.0.0 happens, we can rule out problems from any changes in the 1.x series.

All tests pass. (Could we set up TravisCI or CircleCI for open source purposes to see CI results on GitHub?)

I don't have quick access to test this in a prod or even a test environment. Is it possible for you to try it out and see if there are any red flags?