### PR TITLE
Remove babel transform plugin by default

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,10 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
+    babel: {
+      plugins: [ require.resolve('./launch-darkly-variation-helper') ]
+    },
+
     snippetSearchPaths: ['app', 'tests/dummy'],
     'ember-cli-babel': {
       includePolyfill: true

--- a/index.js
+++ b/index.js
@@ -21,18 +21,8 @@ module.exports = {
     return true;
   },
 
-  included(app) {
+  included() {
     this._super.included.apply(this, arguments);
-
-    if (!this._registeredWithBabel) {
-      app.options = app.options || {};
-      app.options.babel = app.options.babel || {};
-      app.options.babel.plugins = app.options.babel.plugins || [];
-
-      app.options.babel.plugins.unshift(require('./launch-darkly-variation-helper.js'));
-
-      this._registeredWithBabel = true;
-    }
 
     this.import('vendor/ldclient.js');
 


### PR DESCRIPTION
The babel transform that replaces the `variation` JS helper is problematic. It mostly works, however, detecting whether the helper is used inside a computed property is buggy and I'm yet to get it to a point that I feel is solid to be used by default in this addon.

Also, this helper is essentially syntactic sugar and does feel like something that should be an "opt in".

Therefore, this commit removes the babel transform from being added by default and, instead, gives users instructions on how they can include it in their app if they wish to use it.

This is a breaking change.