### PR TITLE
Lazy lookup ld service in window global

### DIFF
--- a/addon/instance-initializers/expose-local-launch-darkly.js
+++ b/addon/instance-initializers/expose-local-launch-darkly.js
@@ -1,5 +1,23 @@
 import { assign } from 'ember-platform';
 
+function defineLdProperty(appInstance) {
+  let define = value => Object.defineProperty(window, 'ld', { value, enumerable: true, writable: true });
+
+  Object.defineProperty(window, 'ld', {
+    configurable: true,
+    enumerable: true,
+    get() {
+      let service = appInstance.lookup('service:launch-darkly-client');
+      define(service);
+      return service;
+    },
+
+    set(value) {
+      define(value);
+    }
+  });
+}
+
 export function initialize(appInstance) {
   let appConfig = appInstance.resolveRegistration('config:environment') || {};
 
@@ -11,8 +29,7 @@ export function initialize(appInstance) {
   config = assign({}, defaults, config);
 
   if (config.local) {
-    let client = appInstance.lookup('service:launch-darkly-client');
-    window.ld = client;
+    defineLdProperty(appInstance);
   }
 }
 


### PR DESCRIPTION
Due to the way that modern versions of Ember initialise services, we need to defer the call to appInstance.lookup until the point that `window.ld` is called.

This is because once that's been called, the client service can not be re-registered for tests.